### PR TITLE
Pass Urban Airship extras as dictionary instead of string; Fix typo in method name

### DIFF
--- a/urbanairship/mobile/android/manifest
+++ b/urbanairship/mobile/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.3.2
+version: 2.3.3
 apiversion: 2
 description: Urban Airship module for push notifications
 author: Jeff English

--- a/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/IntentReceiver.java
+++ b/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/IntentReceiver.java
@@ -54,12 +54,12 @@ public class IntentReceiver extends BroadcastReceiver {
 			String message = intent.getStringExtra(PushManager.EXTRA_ALERT);
 			HashMap<String, String> extras = getPushExtras(intent);
 
-			UrbanAirshipModule.handleReceivedMessage(message, extras.toString(), false, false);		    
+			UrbanAirshipModule.handleReceivedMessage(message, extras.toString(), extras, false, false);		    
 		} else if (action.equals(PushManager.ACTION_NOTIFICATION_OPENED)) {
 			String message = intent.getStringExtra(PushManager.EXTRA_ALERT);
 			HashMap<String, String> extras = getPushExtras(intent);
 			
-			UrbanAirshipModule.handleReceivedMessage(message, extras.toString(), true, true);
+			UrbanAirshipModule.handleReceivedMessage(message, extras.toString(), extras, true, true);
 		} else if (action.equals(PushManager.ACTION_REGISTRATION_FINISHED)) {
 			String apid = intent.getStringExtra(PushManager.EXTRA_APID);
 			Boolean valid = intent.getBooleanExtra(PushManager.EXTRA_REGISTRATION_VALID, false);

--- a/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/IntentReceiver.java
+++ b/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/IntentReceiver.java
@@ -51,20 +51,20 @@ public class IntentReceiver extends BroadcastReceiver {
 		String action = intent.getAction();
 
 		if (action.equals(PushManager.ACTION_PUSH_RECEIVED)) {
-		    String message = intent.getStringExtra(PushManager.EXTRA_ALERT);
-		    HashMap<String, String> extras = getPushExtras(intent);
+			String message = intent.getStringExtra(PushManager.EXTRA_ALERT);
+			HashMap<String, String> extras = getPushExtras(intent);
 
-		    UrbanAirshipModule.handleReceivedMessage(message, extras.toString(), false, false);		    
+			UrbanAirshipModule.handleReceivedMessage(message, extras.toString(), false, false);		    
 		} else if (action.equals(PushManager.ACTION_NOTIFICATION_OPENED)) {
-		    String message = intent.getStringExtra(PushManager.EXTRA_ALERT);
-		    HashMap<String, String> extras = getPushExtras(intent);
-		    
+			String message = intent.getStringExtra(PushManager.EXTRA_ALERT);
+			HashMap<String, String> extras = getPushExtras(intent);
+			
 			UrbanAirshipModule.handleReceivedMessage(message, extras.toString(), true, true);
 		} else if (action.equals(PushManager.ACTION_REGISTRATION_FINISHED)) {
 			String apid = intent.getStringExtra(PushManager.EXTRA_APID);
 			Boolean valid = intent.getBooleanExtra(PushManager.EXTRA_REGISTRATION_VALID, false);
 			
-            UrbanAirshipModule.handleRegistrationComplete(apid, valid);           
+			UrbanAirshipModule.handleRegistrationComplete(apid, valid);           
 		}
 	}
 }

--- a/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/UrbanAirshipModule.java
+++ b/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/UrbanAirshipModule.java
@@ -210,13 +210,13 @@ public class UrbanAirshipModule extends KrollModule {
 	}
 	
 	@Kroll.setProperty @Kroll.method
-	public void setShowOnAppClick(boolean enabled) {
+	public void setShowAppOnClick(boolean enabled) {
 		TiProperties appProperties = TiApplication.getInstance().getAppProperties();
 		appProperties.setBool(PROPERTY_PREFIX + PROPERTY_SHOW_APP_ON_CLICK, enabled);
 	}
 	
 	@Kroll.getProperty @Kroll.method
-	public boolean getShowOnAppClick() {
+	public boolean getShowAppOnClick() {
 		return launchAppOnClick();
 	}
 	

--- a/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/UrbanAirshipModule.java
+++ b/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/UrbanAirshipModule.java
@@ -259,9 +259,10 @@ public class UrbanAirshipModule extends KrollModule {
 				if (intent != null) {
 					String message = intent.getStringExtra("message");
 					String payload = intent.getStringExtra("payload");
+					HashMap<String, String> data = (HashMap<String, String>) intent.getSerializableExtra("data");
 					if (message != null) {
 						Log.d(LCAT,"User clicked notification (synthesized)");
-						handleReceivedMessage(message, payload, true, false);
+						handleReceivedMessage(message, payload, data, true, false);
 					}
 				}
 			}
@@ -278,7 +279,7 @@ public class UrbanAirshipModule extends KrollModule {
 		return uaModule;
 	}
 
-	private static void launchActivity(String message, String payload) {
+	private static void launchActivity(String message, String payload, HashMap<String, String> data) {
 		TiApplication appContext = TiApplication.getInstance();
 		
 		// We need to get the class name for the main application activity. That isn't a problem if
@@ -296,11 +297,12 @@ public class UrbanAirshipModule extends KrollModule {
 		// Set the extras to the message and payload so that they are picked up on relaunch of the activity
 		launch.putExtra("message", message);
 		launch.putExtra("payload", payload);
+		launch.putExtra("data", data);
 		
 		appContext.startActivity(launch);		
 	}
 	
-	public static void handleReceivedMessage(String message, String payload, Boolean clicked, Boolean launchIfNeeded) {
+	public static void handleReceivedMessage(String message, String payload, HashMap<String, String> data, Boolean clicked, Boolean launchIfNeeded) {
 		Log.d(LCAT, "Message: " + message + " Payload: " + payload);
 
 		// Get the currently loaded module object. If the activity has been unloaded then this will
@@ -309,7 +311,7 @@ public class UrbanAirshipModule extends KrollModule {
 
 		// If instructed to bring the app to the foreground when clicked, then launch it
 		if (clicked && launchIfNeeded && launchAppOnClick()) {
-			launchActivity(message, payload);
+			launchActivity(message, payload, data);
 		}		
 
 		if (uaModule != null) {
@@ -317,6 +319,7 @@ public class UrbanAirshipModule extends KrollModule {
 			kd.put("clicked", new Boolean(clicked));
 			kd.put("message", message);
 			kd.put("payload", payload);
+			kd.put("data", data);
 
 			uaModule.fireEvent(EVENT_URBAN_AIRSHIP_CALLBACK, kd);
 		}

--- a/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/UrbanAirshipModule.java
+++ b/urbanairship/mobile/android/src/ti/modules/titanium/urbanAirship/UrbanAirshipModule.java
@@ -45,9 +45,9 @@ public class UrbanAirshipModule extends KrollModule {
 	private static boolean onAppCreateCalled = false;
 		
 	public UrbanAirshipModule() {
-        // Module API level 2 no longer automatically registers the module id or name. In order
-        // to have the module name available for the getModuleByName call we must use the
-        // constructor with a name.
+		// Module API level 2 no longer automatically registers the module id or name. In order
+		// to have the module name available for the getModuleByName call we must use the
+		// constructor with a name.
 		super(ModuleName);
 	}
 
@@ -82,7 +82,7 @@ public class UrbanAirshipModule extends KrollModule {
 		super.listenerAdded(type, count, proxy);
 
 		if (EVENT_URBAN_AIRSHIP_CALLBACK.equals(type)) {
-	        synthesizeMessageIfNeeded();
+			synthesizeMessageIfNeeded();
 		}	
 	}
 	
@@ -97,10 +97,10 @@ public class UrbanAirshipModule extends KrollModule {
 				Log.e(LCAT, "Attempt to access Urban Airship while NOT flying. Check startup and configuration settings.");
 			}
 			return flying;
-	    } catch (Exception e) {
+		} catch (Exception e) {
 			Log.e(LCAT, "Error occurred during isFlying check!!!");
-	    	return false;
-	    }
+			return false;
+		}
 	}
 	
 	@Kroll.getProperty @Kroll.method
@@ -152,7 +152,7 @@ public class UrbanAirshipModule extends KrollModule {
 				PushManager.enablePush();
 			else
 				PushManager.disablePush();
-	    }
+		}
 	}
 	
 	@Kroll.getProperty @Kroll.method
@@ -235,8 +235,8 @@ public class UrbanAirshipModule extends KrollModule {
 			UAirship.takeOff(TiApplication.getInstance(), options);
 			
 			// Airship has successfully taken off. Set up the notification handler
-	        PushManager.shared().setIntentReceiver(IntentReceiver.class);	
-	    } catch (Exception e) {
+			PushManager.shared().setIntentReceiver(IntentReceiver.class);
+		} catch (Exception e) {
 			Log.e(LCAT, "Error occurred during takeoff!!!");
 		}
 	}
@@ -301,44 +301,44 @@ public class UrbanAirshipModule extends KrollModule {
 	}
 	
 	public static void handleReceivedMessage(String message, String payload, Boolean clicked, Boolean launchIfNeeded) {
-	    Log.d(LCAT, "Message: " + message + " Payload: " + payload);
-	    
-	    // Get the currently loaded module object. If the activity has been unloaded then this will
-	    // result in uaModule being set to null.
-	    UrbanAirshipModule uaModule = getModule();
-	    
+		Log.d(LCAT, "Message: " + message + " Payload: " + payload);
+
+		// Get the currently loaded module object. If the activity has been unloaded then this will
+		// result in uaModule being set to null.
+		UrbanAirshipModule uaModule = getModule();
+
 		// If instructed to bring the app to the foreground when clicked, then launch it
 		if (clicked && launchIfNeeded && launchAppOnClick()) {
 			launchActivity(message, payload);
 		}		
 
-	    if (uaModule != null) {
-		    HashMap<String, Object> kd = new HashMap<String, Object>();
-		    kd.put("clicked", new Boolean(clicked));
-		    kd.put("message", message);
-		    kd.put("payload", payload);
-		    
+		if (uaModule != null) {
+			HashMap<String, Object> kd = new HashMap<String, Object>();
+			kd.put("clicked", new Boolean(clicked));
+			kd.put("message", message);
+			kd.put("payload", payload);
+
 			uaModule.fireEvent(EVENT_URBAN_AIRSHIP_CALLBACK, kd);
-	    }
+		}
 	}
 	
-    public static void handleRegistrationComplete(String apid, Boolean valid) {
-        Log.d(LCAT, "APID: " + apid + " IsValid: " + valid);
-        
-	    // Get the currently loaded module object. If the activity has been unloaded then this will
-	    // result in uaModule being set to null.
-        UrbanAirshipModule uaModule = getModule();
-        
-        if (uaModule != null) {
-        	HashMap<String, Object> kd = new HashMap<String, Object>();
-        	kd.put("deviceToken", apid);
-        	kd.put("valid", valid);
-        	if (valid) {
-        		uaModule.fireEvent(EVENT_URBAN_AIRSHIP_SUCCESS, kd);
-        	} else {
-        		kd.put("error", "Error occurred registering device");
-        		uaModule.fireEvent(EVENT_URBAN_AIRSHIP_ERROR, kd);
-        	}
-        }
-    }
+	public static void handleRegistrationComplete(String apid, Boolean valid) {
+		Log.d(LCAT, "APID: " + apid + " IsValid: " + valid);
+
+		// Get the currently loaded module object. If the activity has been unloaded then this will
+		// result in uaModule being set to null.
+		UrbanAirshipModule uaModule = getModule();
+
+		if (uaModule != null) {
+			HashMap<String, Object> kd = new HashMap<String, Object>();
+			kd.put("deviceToken", apid);
+			kd.put("valid", valid);
+			if (valid) {
+				uaModule.fireEvent(EVENT_URBAN_AIRSHIP_SUCCESS, kd);
+			} else {
+				kd.put("error", "Error occurred registering device");
+				uaModule.fireEvent(EVENT_URBAN_AIRSHIP_ERROR, kd);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Brings Android module up to parity with `.data` property from iOS notifications:

http://docs.appcelerator.com/titanium/latest/#!/api/PushNotificationData