### PR TITLE
Camera not required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 build.properties
 build
 .svn
+barcode/mobile/android/dist
+barcode/mobile/android/libs

--- a/barcode/mobile/android/documentation/index.md
+++ b/barcode/mobile/android/documentation/index.md
@@ -18,6 +18,9 @@ the iOS and Android modules in to full parity. When upgrading to 1.5, you will n
 - BREAKING CHANGE: Android now properly fires the "cancel" event, as documented. It was firing the "canceled" event.
 - Ensure that you assign the module object that is returned from "require('ti.barcode')" to a variable or your event listeners may not receive the barcode events
 
+## Warning for Android devices.
+The module feature-required entries have been modified so that your app can be installed on devices that do not have a main camera, like the Nexus 7. However, you now need to check for a camera before attempting to use the module in your app.
+
 ## Accessing the Ti.Barcode Module
 To access this module from JavaScript, you would do the following:
 

--- a/barcode/mobile/android/manifest
+++ b/barcode/mobile/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 2.3.4
+version: 2.3.5
 apiversion: 2
 description: Lets you process 1D/2D barcodes.
 author: Stephen Tramer & Jeff English

--- a/barcode/mobile/android/timodule.xml
+++ b/barcode/mobile/android/timodule.xml
@@ -123,7 +123,8 @@
                 </activity>
             </application>
 
-            <uses-feature android:name="android.hardware.camera"/>
+            <!-- IMPORTANT: android.hardware.camera is set to not-required. YOU MUST CHECK FOR A CAMERA BEFORE LAUNCHING THE MODULE -->
+            <uses-feature android:name="android.hardware.camera" android:required="false"/>
             <uses-feature android:name="android.hardware.camera.autofocus" android:required="false"/>
             <uses-feature android:name="android.hardware.camera.flash" android:required="false"/>
             <uses-feature android:name="android.hardware.screen.landscape"/>


### PR DESCRIPTION
I modified the manifest and documentation to allow for apps that include this module to be *INSTALLED* on devices without a primary camera, like the Nexus 7. The programmer will need to check for a camera, though.