### PR TITLE
Add the iOS url scheme suffix feature for Facebook

### DIFF
--- a/facebook/mobile/ios/Classes/FBConnect/Facebook.m
+++ b/facebook/mobile/ios/Classes/FBConnect/Facebook.m
@@ -83,7 +83,7 @@ static NSString *const FBexpirationDatePropertyName = @"expirationDate";
 
 - (id)initWithAppId:(NSString *)appId
         andDelegate:(id<FBSessionDelegate>)delegate {
-    self = [self initWithAppId:appId urlSchemeSuffix:nil andDelegate:delegate];
+    self = [self initWithAppId:appId urlSchemeSuffix:_urlSchemeSuffix andDelegate:delegate];
     return self;
 }
 

--- a/facebook/mobile/ios/Classes/FacebookModule.h
+++ b/facebook/mobile/ios/Classes/FacebookModule.h
@@ -22,6 +22,7 @@
 	NSString *url;
 	NSString *appid;
 	NSArray *permissions;
+	NSString *urlSchemeSuffix;
 	NSMutableArray *stateListeners;
     BOOL forceDialogAuth;
 }

--- a/facebook/mobile/ios/Classes/FacebookModule.m
+++ b/facebook/mobile/ios/Classes/FacebookModule.m
@@ -94,8 +94,8 @@
 	NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
 	NSString *uid_ = [defaults objectForKey:@"FBUserId"];
 	appid = [[defaults stringForKey:@"FBAppId"] copy];
-	facebook = [[Facebook alloc] initWithAppId:appid urlSchemeSuffix:nil andDelegate:self];
 	
+	facebook = [[Facebook alloc] initWithAppId:appid urlSchemeSuffix:urlSchemeSuffix andDelegate:self];
 	VerboseLog(@"[DEBUG] facebook _restore, uid = %@",uid_);
 	if (uid_)
 	{
@@ -121,6 +121,7 @@
 	RELEASE_TO_NIL(appid);
 	RELEASE_TO_NIL(permissions);
 	RELEASE_TO_NIL(uid);
+	RELEASE_TO_NIL(urlSchemeSuffix);
 	[super dealloc];
 }
 
@@ -161,6 +162,7 @@
 -(void)startup
 {
 	VerboseLog(@"[DEBUG] facebook startup");
+	[facebook setUrlSchemeSuffix:'myappsuffix'];
 	[super startup];
 	TiThreadPerformOnMainThread(^{
 		NSNotificationCenter * nc = [NSNotificationCenter defaultCenter];
@@ -316,6 +318,20 @@ if(![x isKindOfClass:[t class]]){ \
 	return permissions;
 }
 
+
+/**
+ * JS example:
+ *
+ * var facebook = require('facebook');
+ * facebook.urlSchemeSuffix = 'myappsuffix';
+ * alert(facebook.urlSchemeSuffix);
+ *
+ */
+-(id)urlSchemeSuffix
+{
+	return urlSchemeSuffix;
+}
+
 /**
  * JS example:
  *
@@ -379,6 +395,21 @@ if(![x isKindOfClass:[t class]]){ \
 {
 	RELEASE_TO_NIL(permissions);
 	permissions = [arg retain];
+}
+
+/**
+ * JS example:
+ *
+ * var facebook = require('facebook');
+ * facebook.urlSchemeSuffix = 'myappsuffix';
+ * alert(facebook.urlSchemeSuffix);
+ *
+ */
+-(void)setUrlSchemeSuffix:(id)arg
+{
+	RELEASE_TO_NIL(urlSchemeSuffix);
+	urlSchemeSuffix = [arg copy];
+	[facebook setUrlSchemeSuffix:urlSchemeSuffix];
 }
 
 /**


### PR DESCRIPTION
This is a feature we use a lot to have severals iOS apps using the same Facebook App.

You can find the Facebook documentation here : https://developers.facebook.com/docs/howtos/share-appid-across-multiple-apps-ios-sdk/

I posted a Q&A on this topic : http://developer.appcelerator.com/question/137857/how-to-define-a-specific-facebook-url-scheme-suffix-for-my-ios-app
I also posted a JIRA : https://jira.appcelerator.org/browse/TIMOB-9701

This JIRA is almost 1 year-old and still opened, we patched your module to make it works on our apps. It would be great to integrate this patch to the main code.